### PR TITLE
Fix release workflow: update Flutter to 3.41.4

### DIFF
--- a/.github/workflows/multi-platform-release.yml
+++ b/.github/workflows/multi-platform-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.29.2'
+          flutter-version: '3.41.4'
           channel: 'stable'
           
       - name: Update pubspec version and changelog
@@ -238,7 +238,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.29.2'
+          flutter-version: '3.41.4'
           channel: 'stable'
           
       - name: Update changelog


### PR DESCRIPTION
## Summary
- Update pinned Flutter version from 3.29.2 to 3.41.4 in multi-platform release workflow
- flutter_lints 6.0.0 requires a newer SDK, causing all platform builds to fail at `flutter pub get`

## Test plan
- [ ] Re-run v0.2.0 release workflow after merge