### PR TITLE
Release 0.2.1

### DIFF
--- a/dart_rpg/lib/models/combat.dart
+++ b/dart_rpg/lib/models/combat.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+import 'quest.dart';
+
+/// Enum representing the status of a combat encounter
+enum CombatStatus {
+  active,
+  won,
+  lost,
+  fled;
+
+  String get displayName {
+    switch (this) {
+      case CombatStatus.active:
+        return 'Active';
+      case CombatStatus.won:
+        return 'Won';
+      case CombatStatus.lost:
+        return 'Lost';
+      case CombatStatus.fled:
+        return 'Fled';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case CombatStatus.active:
+        return Icons.sports_martial_arts;
+      case CombatStatus.won:
+        return Icons.emoji_events;
+      case CombatStatus.lost:
+        return Icons.dangerous;
+      case CombatStatus.fled:
+        return Icons.directions_run;
+    }
+  }
+
+  Color get color {
+    switch (this) {
+      case CombatStatus.active:
+        return Colors.red;
+      case CombatStatus.won:
+        return Colors.green;
+      case CombatStatus.lost:
+        return Colors.grey;
+      case CombatStatus.fled:
+        return Colors.orange;
+    }
+  }
+}
+
+/// Class representing a combat encounter in the game
+class Combat {
+  final String id;
+  String title;
+  final String characterId;
+  QuestRank rank;
+  int _progressTicks;
+  CombatStatus status;
+  bool isInControl;
+  String notes;
+  final DateTime createdAt;
+  DateTime? endedAt;
+
+  Combat({
+    String? id,
+    required this.title,
+    required this.characterId,
+    required this.rank,
+    int progressTicks = 0,
+    this.status = CombatStatus.active,
+    this.isInControl = true,
+    this.notes = '',
+    DateTime? createdAt,
+    this.endedAt,
+  })  : id = id ?? const Uuid().v4(),
+        _progressTicks = progressTicks,
+        createdAt = createdAt ?? DateTime.now();
+
+  /// Get the progress in boxes (0-10)
+  int get progress => (_progressTicks / 4).floor();
+
+  /// Get the total number of ticks (0-40)
+  int get progressTicks => _progressTicks;
+
+  /// Get the number of ticks in a specific box (0-4)
+  int getTicksInBox(int boxIndex) {
+    if (boxIndex < progress) {
+      return 4;
+    } else if (boxIndex == progress && _progressTicks % 4 > 0) {
+      return _progressTicks % 4;
+    } else {
+      return 0;
+    }
+  }
+
+  /// Get the number of ticks to add based on rank
+  int getTicksForRank() {
+    switch (rank) {
+      case QuestRank.troublesome:
+        return 12;
+      case QuestRank.dangerous:
+        return 8;
+      case QuestRank.formidable:
+        return 4;
+      case QuestRank.extreme:
+        return 2;
+      case QuestRank.epic:
+        return 1;
+    }
+  }
+
+  /// Add ticks based on rank
+  void addTicksForRank() {
+    final ticksToAdd = getTicksForRank();
+    _progressTicks = (_progressTicks + ticksToAdd).clamp(0, 40);
+  }
+
+  /// Remove ticks based on rank
+  void removeTicksForRank() {
+    final ticksToRemove = getTicksForRank();
+    _progressTicks = (_progressTicks - ticksToRemove).clamp(0, 40);
+  }
+
+  /// Update progress ticks directly
+  void updateProgressTicks(int newTicks) {
+    _progressTicks = newTicks.clamp(0, 40);
+  }
+
+  /// End the combat with a given status
+  void end(CombatStatus endStatus) {
+    status = endStatus;
+    endedAt = DateTime.now();
+  }
+
+  factory Combat.fromJson(Map<String, dynamic> json) {
+    return Combat(
+      id: json['id'],
+      title: json['title'],
+      characterId: json['characterId'],
+      rank: QuestRank.values.firstWhere(
+        (r) => r.name == json['rank'],
+        orElse: () => QuestRank.dangerous,
+      ),
+      progressTicks: json['progressTicks'] ?? 0,
+      status: CombatStatus.values.firstWhere(
+        (s) => s.name == json['status'],
+        orElse: () => CombatStatus.active,
+      ),
+      isInControl: json['isInControl'] ?? true,
+      notes: json['notes'] ?? '',
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse(json['createdAt'])
+          : DateTime.now(),
+      endedAt: json['endedAt'] != null
+          ? DateTime.parse(json['endedAt'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'characterId': characterId,
+      'rank': rank.name,
+      'progressTicks': _progressTicks,
+      'status': status.name,
+      'isInControl': isInControl,
+      'notes': notes,
+      'createdAt': createdAt.toIso8601String(),
+      'endedAt': endedAt?.toIso8601String(),
+    };
+  }
+}

--- a/dart_rpg/lib/models/game.dart
+++ b/dart_rpg/lib/models/game.dart
@@ -5,6 +5,7 @@ import '../utils/logging_service.dart';
 import 'ai_config.dart';
 import 'character.dart';
 import 'clock.dart';
+import 'combat.dart';
 import 'location.dart';
 import 'recent_move_entry.dart';
 import 'session.dart';
@@ -24,6 +25,7 @@ class Game {
   List<Quest> quests;
   List<Connection> connections;
   List<Clock> clocks;
+  List<Combat> combats;
   List<Faction> factions;
   List<NetworkRoute> routes;
   Character? mainCharacter;
@@ -52,6 +54,7 @@ class Game {
     List<Quest>? quests,
     List<Connection>? connections,
     List<Clock>? clocks,
+    List<Combat>? combats,
     List<Faction>? factions,
     List<NetworkRoute>? routes,
     this.mainCharacter,
@@ -81,6 +84,7 @@ class Game {
         quests = quests ?? [],
         connections = connections ?? [],
         clocks = clocks ?? [],
+        combats = combats ?? [],
         factions = factions ?? [],
         routes = routes ?? [],
         recentMoves = recentMoves ?? [],
@@ -130,6 +134,7 @@ class Game {
       'quests': quests.map((q) => q.toJson()).toList(),
       'connections': connections.map((c) => c.toJson()).toList(),
       'clocks': clocks.map((c) => c.toJson()).toList(),
+      'combats': combats.map((c) => c.toJson()).toList(),
       'factions': factions.map((f) => f.toJson()).toList(),
       'routes': routes.map((r) => r.toJson()).toList(),
       'tutorialsEnabled': tutorialsEnabled,
@@ -190,6 +195,9 @@ class Game {
           .toList() ?? [],
       clocks: (json['clocks'] as List?)
           ?.map((c) => Clock.fromJson(c))
+          .toList() ?? [],
+      combats: (json['combats'] as List?)
+          ?.map((c) => Combat.fromJson(c))
           .toList() ?? [],
       factions: (json['factions'] as List?)
           ?.map((f) => Faction.fromJson(f))
@@ -329,6 +337,18 @@ class Game {
 
   List<Clock> getAllClocks() {
     return List.from(clocks);
+  }
+
+  void addCombat(Combat combat) {
+    combats.add(combat);
+  }
+
+  List<Combat> getCombatsForCharacter(String characterId) {
+    return combats.where((c) => c.characterId == characterId).toList();
+  }
+
+  List<Combat> get activeCombats {
+    return combats.where((c) => c.status == CombatStatus.active).toList();
   }
 
   List<Quest> getQuestsForCharacter(String characterId) {

--- a/dart_rpg/lib/models/journal_entry.dart
+++ b/dart_rpg/lib/models/journal_entry.dart
@@ -169,6 +169,7 @@ class JournalEntry {
   DateTime updatedAt;
   List<String> linkedCharacterIds;
   List<String> linkedLocationIds;
+  List<String> linkedFactionIds;
   List<MoveRoll> moveRolls; // Changed from single moveRoll to list
   List<OracleRoll> oracleRolls; // Changed from single oracleRoll to list
   List<String> embeddedImages; // URLs of embedded images
@@ -183,6 +184,7 @@ class JournalEntry {
     DateTime? updatedAt,
     List<String>? linkedCharacterIds,
     List<String>? linkedLocationIds,
+    List<String>? linkedFactionIds,
     List<MoveRoll>? moveRolls,
     List<OracleRoll>? oracleRolls,
     List<String>? embeddedImages,
@@ -193,6 +195,7 @@ class JournalEntry {
         updatedAt = updatedAt ?? DateTime.now(),
         linkedCharacterIds = linkedCharacterIds ?? [],
         linkedLocationIds = linkedLocationIds ?? [],
+        linkedFactionIds = linkedFactionIds ?? [],
         moveRolls = moveRolls ?? [],
         oracleRolls = oracleRolls ?? [],
         embeddedImages = embeddedImages ?? [],
@@ -207,6 +210,7 @@ class JournalEntry {
       'updatedAt': updatedAt.toIso8601String(),
       'linkedCharacterIds': linkedCharacterIds,
       'linkedLocationIds': linkedLocationIds,
+      'linkedFactionIds': linkedFactionIds,
       'moveRolls': moveRolls.map((roll) => roll.toJson()).toList(),
       'oracleRolls': oracleRolls.map((roll) => roll.toJson()).toList(),
       'embeddedImages': embeddedImages,
@@ -252,6 +256,7 @@ class JournalEntry {
       updatedAt: DateTime.parse(json['updatedAt']),
       linkedCharacterIds: (json['linkedCharacterIds'] as List?)?.cast<String>() ?? [],
       linkedLocationIds: (json['linkedLocationIds'] as List?)?.cast<String>() ?? [],
+      linkedFactionIds: (json['linkedFactionIds'] as List?)?.cast<String>() ?? [],
       moveRolls: moveRollsList,
       oracleRolls: oracleRollsList,
       embeddedImages: (json['embeddedImages'] as List?)?.cast<String>() ?? [],
@@ -283,6 +288,16 @@ class JournalEntry {
 
   void unlinkLocation(String locationId) {
     linkedLocationIds.remove(locationId);
+  }
+
+  void linkFaction(String factionId) {
+    if (!linkedFactionIds.contains(factionId)) {
+      linkedFactionIds.add(factionId);
+    }
+  }
+
+  void unlinkFaction(String factionId) {
+    linkedFactionIds.remove(factionId);
   }
 
   // Backward compatibility getters and setters for single moveRoll/oracleRoll

--- a/dart_rpg/lib/providers/combat_operations_mixin.dart
+++ b/dart_rpg/lib/providers/combat_operations_mixin.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/foundation.dart';
+import '../models/game.dart';
+import '../models/session.dart';
+import '../models/combat.dart';
+import '../models/quest.dart';
+import '../utils/dice_roller.dart';
+
+/// Mixin that encapsulates all combat-related operations.
+///
+/// Requires the host class to provide access to game state via
+/// [combatGame], [combatSession], and [persistAndNotify].
+mixin CombatOperationsMixin on ChangeNotifier {
+  Game? get combatGame;
+  Session? get combatSession;
+  Future<void> persistAndNotify();
+
+  Future<Combat> createCombat(
+    String title,
+    String characterId,
+    QuestRank rank, {
+    bool isInControl = true,
+  }) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    combatGame!.characters.firstWhere(
+      (c) => c.id == characterId,
+      orElse: () => throw Exception('Character not found'),
+    );
+
+    final combat = Combat(
+      title: title,
+      characterId: characterId,
+      rank: rank,
+      isInControl: isInControl,
+    );
+
+    combatGame!.combats.add(combat);
+
+    await persistAndNotify();
+
+    return combat;
+  }
+
+  Future<void> addCombatTicksForRank(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.addTicksForRank();
+
+    await persistAndNotify();
+  }
+
+  Future<void> addCombatTicksForRankDouble(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.addTicksForRank();
+    combat.addTicksForRank();
+
+    await persistAndNotify();
+  }
+
+  Future<void> removeCombatTicksForRank(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.removeTicksForRank();
+
+    await persistAndNotify();
+  }
+
+  Future<void> updateCombatProgressTicks(String combatId, int ticks) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.updateProgressTicks(ticks);
+
+    await persistAndNotify();
+  }
+
+  Future<void> setCombatControl(String combatId, bool inControl) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.isInControl = inControl;
+
+    await persistAndNotify();
+  }
+
+  Future<void> toggleCombatControl(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.isInControl = !combat.isInControl;
+
+    await persistAndNotify();
+  }
+
+  Future<Map<String, dynamic>> makeCombatProgressRoll(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    final result = DiceRoller.rollProgressMove(progressValue: combat.progress);
+
+    if (combatSession != null) {
+      final character = combatGame!.characters.firstWhere(
+        (c) => c.id == combat.characterId,
+        orElse: () => throw Exception('Character not found'),
+      );
+
+      final entry = combatSession!.createNewEntry(
+        'Progress roll for combat "${combat.title}" by ${character.name}.\n'
+        'Progress: ${combat.progress}/10 (${combat.progressTicks} ticks)\n'
+        'Challenge Dice: ${result['challengeDice'][0]}, ${result['challengeDice'][1]}\n'
+        'Outcome: ${result['outcome']}'
+      );
+
+      entry.metadata = {'sourceScreen': 'combat'};
+    }
+
+    await persistAndNotify();
+
+    return result;
+  }
+
+  Future<void> endCombat(String combatId, CombatStatus endStatus) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    final combat = combatGame!.combats.firstWhere(
+      (c) => c.id == combatId,
+      orElse: () => throw Exception('Combat not found'),
+    );
+
+    combat.end(endStatus);
+
+    await persistAndNotify();
+  }
+
+  Future<void> deleteCombat(String combatId) async {
+    if (combatGame == null) {
+      throw Exception('No game selected');
+    }
+
+    combatGame!.combats.removeWhere((c) => c.id == combatId);
+
+    await persistAndNotify();
+  }
+}

--- a/dart_rpg/lib/providers/datasworn_provider.dart
+++ b/dart_rpg/lib/providers/datasworn_provider.dart
@@ -34,6 +34,7 @@ class DataswornProvider extends ChangeNotifier {
     
     _isLoading = true;
     _error = null;
+    _customOraclesLoaded = false;
     notifyListeners();
 
     try {

--- a/dart_rpg/lib/providers/game_provider.dart
+++ b/dart_rpg/lib/providers/game_provider.dart
@@ -16,12 +16,13 @@ import '../utils/logging_service.dart';
 import 'datasworn_provider.dart';
 import 'image_manager_provider.dart';
 import 'clock_operations_mixin.dart';
+import 'combat_operations_mixin.dart';
 import 'quest_operations_mixin.dart';
 import 'connection_operations_mixin.dart';
 import 'faction_operations_mixin.dart';
 import 'route_operations_mixin.dart';
 
-class GameProvider extends ChangeNotifier with ClockOperationsMixin, QuestOperationsMixin, ConnectionOperationsMixin, FactionOperationsMixin, RouteOperationsMixin {
+class GameProvider extends ChangeNotifier with ClockOperationsMixin, CombatOperationsMixin, QuestOperationsMixin, ConnectionOperationsMixin, FactionOperationsMixin, RouteOperationsMixin {
 
   List<GameSummary> _gameSummaries = [];
   Game? _currentGame;
@@ -44,11 +45,15 @@ class GameProvider extends ChangeNotifier with ClockOperationsMixin, QuestOperat
     await _saveCurrentGame();
   }
 
-  // Mixin interface for ClockOperationsMixin and QuestOperationsMixin
+  // Mixin interface for ClockOperationsMixin, CombatOperationsMixin, and QuestOperationsMixin
   @override
   Game? get clockGame => _currentGame;
   @override
   Session? get clockSession => _currentSession;
+  @override
+  Game? get combatGame => _currentGame;
+  @override
+  Session? get combatSession => _currentSession;
   @override
   Game? get questGame => _currentGame;
   @override

--- a/dart_rpg/lib/screens/game_screen.dart
+++ b/dart_rpg/lib/screens/game_screen.dart
@@ -158,7 +158,10 @@ class _GameScreenState extends State<GameScreen> {
   Widget _buildBody(BuildContext context, Game game, GameProvider gameProvider) {
     switch (_selectedIndex) {
       case 0:
-        return JournalScreen(gameId: game.id);
+        return JournalScreen(
+          gameId: game.id,
+          onNavigateToQuests: () => setState(() { _selectedIndex = 3; }),
+        );
       case 1:
         return CharacterScreen(gameId: game.id);
       case 2:

--- a/dart_rpg/lib/screens/game_settings_screen.dart
+++ b/dart_rpg/lib/screens/game_settings_screen.dart
@@ -45,7 +45,7 @@ class _GameSettingsScreenState extends State<GameSettingsScreen> {
                 game: game,
                 gameProvider: gameProvider,
                 truths: dataswornProvider.truths,
-                initiallyExpanded: true,
+                initiallyExpanded: game.selectedTruths.isEmpty,
                 showDividers: true,
                 showHelpText: true,
               ),

--- a/dart_rpg/lib/screens/home_screen.dart
+++ b/dart_rpg/lib/screens/home_screen.dart
@@ -180,6 +180,7 @@ class HomeScreen extends StatelessWidget {
                           if (summary.dataswornSource != null && context.mounted) {
                             final dataswornProvider = Provider.of<DataswornProvider>(context, listen: false);
                             await dataswornProvider.loadDatasworn(summary.dataswornSource!);
+                            await dataswornProvider.loadCustomOracles();
                           }
 
                           if (context.mounted) {
@@ -253,6 +254,7 @@ class HomeScreen extends StatelessWidget {
                                             if (summary.dataswornSource != null && context.mounted) {
                                               final dataswornProvider = Provider.of<DataswornProvider>(context, listen: false);
                                               await dataswornProvider.loadDatasworn(summary.dataswornSource!);
+                                              await dataswornProvider.loadCustomOracles();
                                             }
 
                                             if (context.mounted) {

--- a/dart_rpg/lib/screens/journal_entry_screen.dart
+++ b/dart_rpg/lib/screens/journal_entry_screen.dart
@@ -33,6 +33,10 @@ class NewEntryIntent extends Intent {
   const NewEntryIntent();
 }
 
+class CombatIntent extends Intent {
+  const CombatIntent();
+}
+
 class JournalEntryScreen extends StatefulWidget {
   final String? entryId;
   final String? sourceScreen;
@@ -242,6 +246,15 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
     }
   }
   
+  // Open the Quick Roll panel with combat section visible
+  void _openCombatInQuickRoll() {
+    if (_isEditing) {
+      setState(() {
+        _quickRollPanelOpen = true;
+      });
+    }
+  }
+
   // Show the Quests screen as an overlay so the journal state is preserved
   void _navigateToQuests(BuildContext context) {
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
@@ -879,8 +892,10 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
             const QuestsIntent(),
         LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyM): 
             const MovesIntent(),
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyN): 
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyN):
             const NewEntryIntent(),
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyB):
+            const CombatIntent(),
       },
       actions: {
         QuestsIntent: CallbackAction<QuestsIntent>(
@@ -904,6 +919,12 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
             if (_isEditing) {
               _saveAndCreateNew();
             }
+            return null;
+          },
+        ),
+        CombatIntent: CallbackAction<CombatIntent>(
+          onInvoke: (CombatIntent intent) {
+            _openCombatInQuickRoll();
             return null;
           },
         ),
@@ -1025,6 +1046,9 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                       onQuestRequested: widget.sourceScreen != 'quests' ? () {
                                         _navigateToQuests(context);
                                       } : null,
+                                      onCombatRequested: () {
+                                        _openCombatInQuickRoll();
+                                      },
                                       onNewEntryRequested: _saveAndCreateNew,
                                       onLinkedItemsPressed: () {
                                         // This is handled internally by the JournalEntryEditor

--- a/dart_rpg/lib/screens/journal_entry_screen.dart
+++ b/dart_rpg/lib/screens/journal_entry_screen.dart
@@ -1030,25 +1030,30 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                         // This is handled internally by the JournalEntryEditor
                                       },
                                     )
-                                  : JournalEntryViewer(
-                                      content: _content,
-                                      moveRolls: _moveRolls,
-                                      oracleRolls: _oracleRolls,
-                                      onCharacterTap: (character) {
-                                        _showCharacterDetailsDialog(context, character);
+                                  : GestureDetector(
+                                      onDoubleTap: () {
+                                        setState(() { _isEditing = true; });
                                       },
-                                      onLocationTap: (location) {
-                                        _showLocationDetailsDialog(context, location);
-                                      },
-                                      onFactionTap: (faction) {
-                                        _showFactionDetailsDialog(context, faction);
-                                      },
-                                      onMoveRollTap: (moveRoll) {
-                                        _showMoveRollDetailsDialog(context, moveRoll);
-                                      },
-                                      onOracleRollTap: (oracleRoll) {
-                                        _showOracleRollDetailsDialog(context, oracleRoll);
-                                      },
+                                      child: JournalEntryViewer(
+                                        content: _content,
+                                        moveRolls: _moveRolls,
+                                        oracleRolls: _oracleRolls,
+                                        onCharacterTap: (character) {
+                                          _showCharacterDetailsDialog(context, character);
+                                        },
+                                        onLocationTap: (location) {
+                                          _showLocationDetailsDialog(context, location);
+                                        },
+                                        onFactionTap: (faction) {
+                                          _showFactionDetailsDialog(context, faction);
+                                        },
+                                        onMoveRollTap: (moveRoll) {
+                                          _showMoveRollDetailsDialog(context, moveRoll);
+                                        },
+                                        onOracleRollTap: (oracleRoll) {
+                                          _showOracleRollDetailsDialog(context, oracleRoll);
+                                        },
+                                      ),
                                     ),
                               ),
                             ),

--- a/dart_rpg/lib/screens/journal_entry_screen.dart
+++ b/dart_rpg/lib/screens/journal_entry_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../providers/game_provider.dart';
 import '../models/journal_entry.dart';
 import '../models/character.dart';
+import '../models/faction.dart';
 import '../models/location.dart';
 import '../utils/logging_service.dart';
 import '../widgets/journal/journal_entry_editor.dart';
@@ -55,6 +56,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
   String? _richContent;
   List<String> _linkedCharacterIds = [];
   List<String> _linkedLocationIds = [];
+  List<String> _linkedFactionIds = [];
   List<MoveRoll> _moveRolls = [];
   List<OracleRoll> _oracleRolls = [];
   List<String> _embeddedImages = [];
@@ -85,11 +87,12 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
     _linkedItemsManager = LinkedItemsManager(
       linkedCharacterIds: _linkedCharacterIds,
       linkedLocationIds: _linkedLocationIds,
+      linkedFactionIds: _linkedFactionIds,
       moveRolls: _moveRolls,
       oracleRolls: _oracleRolls,
       embeddedImages: _embeddedImages,
     );
-    
+
     // Initialize the autocomplete system
     _autocompleteSystem = AutocompleteSystem();
     
@@ -128,6 +131,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -141,6 +145,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -151,6 +156,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
           entry.richContent = _richContent;
           entry.linkedCharacterIds = _linkedCharacterIds;
           entry.linkedLocationIds = _linkedLocationIds;
+          entry.linkedFactionIds = _linkedFactionIds;
           entry.moveRolls = _moveRolls;
           entry.oracleRolls = _oracleRolls;
           entry.embeddedImages = _embeddedImages;
@@ -195,6 +201,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -208,6 +215,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -218,6 +226,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -304,7 +313,8 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         // Update linked entities
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
-        
+        entry.linkedFactionIds = _linkedFactionIds;
+
         // Update rolls
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
@@ -325,6 +335,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
           entry.richContent = _richContent;
           entry.linkedCharacterIds = _linkedCharacterIds;
           entry.linkedLocationIds = _linkedLocationIds;
+          entry.linkedFactionIds = _linkedFactionIds;
           entry.moveRolls = _moveRolls;
           entry.oracleRolls = _oracleRolls;
           entry.embeddedImages = _embeddedImages;
@@ -348,7 +359,8 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
           // Update linked entities
           entry.linkedCharacterIds = _linkedCharacterIds;
           entry.linkedLocationIds = _linkedLocationIds;
-          
+          entry.linkedFactionIds = _linkedFactionIds;
+
           // Update rolls
           entry.moveRolls = _moveRolls;
           entry.oracleRolls = _oracleRolls;
@@ -396,6 +408,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
             _richContent = entry.richContent;
             _linkedCharacterIds = List.from(entry.linkedCharacterIds);
             _linkedLocationIds = List.from(entry.linkedLocationIds);
+            _linkedFactionIds = List.from(entry.linkedFactionIds);
             _moveRolls = List.from(entry.moveRolls);
             _oracleRolls = List.from(entry.oracleRolls);
             _embeddedImages = List.from(entry.embeddedImages);
@@ -404,11 +417,12 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
             _linkedItemsManager = LinkedItemsManager(
               linkedCharacterIds: _linkedCharacterIds,
               linkedLocationIds: _linkedLocationIds,
+              linkedFactionIds: _linkedFactionIds,
               moveRolls: _moveRolls,
               oracleRolls: _oracleRolls,
               embeddedImages: _embeddedImages,
             );
-            
+
             // Update the editor controller with the loaded content
             _editorController.text = entry.content;
           });
@@ -451,6 +465,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -482,7 +497,8 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         // Update linked entities
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
-        
+        entry.linkedFactionIds = _linkedFactionIds;
+
         // Update rolls
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
@@ -509,6 +525,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -547,6 +564,49 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
 
   void _showLocationDetailsDialog(BuildContext context, Location location) =>
       JournalDetailDialogs.showLocationDetails(context, location);
+
+  void _showFactionDetailsDialog(BuildContext context, Faction faction) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(faction.name),
+          content: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Icon(faction.type.icon, size: 16),
+                    const SizedBox(width: 4),
+                    Text(faction.type.displayName),
+                    const SizedBox(width: 16),
+                    Text('Influence: ${faction.influence.displayName}'),
+                  ],
+                ),
+                if (faction.description.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Description:',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(faction.description),
+                ],
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
   
   void _showQuickAddCharacterDialog(BuildContext context) {
     QuickAddDialogs.showAddCharacter(
@@ -674,6 +734,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -693,7 +754,8 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         // Update linked entities
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
-        
+        entry.linkedFactionIds = _linkedFactionIds;
+
         // Update rolls
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
@@ -712,6 +774,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         entry.richContent = _richContent;
         entry.linkedCharacterIds = _linkedCharacterIds;
         entry.linkedLocationIds = _linkedLocationIds;
+        entry.linkedFactionIds = _linkedFactionIds;
         entry.moveRolls = _moveRolls;
         entry.oracleRolls = _oracleRolls;
         entry.embeddedImages = _embeddedImages;
@@ -730,18 +793,20 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
         _richContent = null;
         _linkedCharacterIds = [];
         _linkedLocationIds = [];
+        _linkedFactionIds = [];
         _moveRolls = [];
         _oracleRolls = [];
         _embeddedImages = [];
         _createdEntryId = null;
-        
+
         // Reset the editor controller
         _editorController.clear();
-        
+
         // Update the linked items manager
         _linkedItemsManager = LinkedItemsManager(
           linkedCharacterIds: _linkedCharacterIds,
           linkedLocationIds: _linkedLocationIds,
+          linkedFactionIds: _linkedFactionIds,
           moveRolls: _moveRolls,
           oracleRolls: _oracleRolls,
           embeddedImages: _embeddedImages,
@@ -936,6 +1001,13 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                           }
                                         });
                                       },
+                                      onFactionLinked: (factionId) {
+                                        setState(() {
+                                          if (!_linkedFactionIds.contains(factionId)) {
+                                            _linkedFactionIds.add(factionId);
+                                          }
+                                        });
+                                      },
                                       onImageAdded: (imageUrl) {
                                         setState(() {
                                           if (!_embeddedImages.contains(imageUrl)) {
@@ -968,6 +1040,9 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                       onLocationTap: (location) {
                                         _showLocationDetailsDialog(context, location);
                                       },
+                                      onFactionTap: (faction) {
+                                        _showFactionDetailsDialog(context, faction);
+                                      },
                                       onMoveRollTap: (moveRoll) {
                                         _showMoveRollDetailsDialog(context, moveRoll);
                                       },
@@ -982,6 +1057,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                             if (!_isEditing && (
                                 _linkedCharacterIds.isNotEmpty ||
                                 _linkedLocationIds.isNotEmpty ||
+                                _linkedFactionIds.isNotEmpty ||
                                 _moveRolls.isNotEmpty ||
                                 _oracleRolls.isNotEmpty
                               ))
@@ -997,6 +1073,7 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                         richContent: _richContent,
                                         linkedCharacterIds: _linkedCharacterIds,
                                         linkedLocationIds: _linkedLocationIds,
+                                        linkedFactionIds: _linkedFactionIds,
                                         moveRolls: _moveRolls,
                                         oracleRolls: _oracleRolls,
                                         embeddedImages: _embeddedImages,
@@ -1012,6 +1089,12 @@ class _JournalEntryScreenState extends State<JournalEntryScreen> {
                                         final location = gameProvider.currentGame!.locations
                                             .firstWhere((l) => l.id == locationId);
                                         _showLocationDetailsDialog(context, location);
+                                      },
+                                      onFactionTap: (factionId) {
+                                        final gameProvider = Provider.of<GameProvider>(context, listen: false);
+                                        final faction = gameProvider.currentGame!.factions
+                                            .firstWhere((f) => f.id == factionId);
+                                        _showFactionDetailsDialog(context, faction);
                                       },
                                       onMoveRollTap: (moveRoll) {
                                         _showMoveRollDetailsDialog(context, moveRoll);

--- a/dart_rpg/lib/screens/journal_screen.dart
+++ b/dart_rpg/lib/screens/journal_screen.dart
@@ -18,8 +18,9 @@ import '../widgets/journal/end_session_dialog.dart';
 
 class JournalScreen extends StatefulWidget {
   final String gameId;
+  final VoidCallback? onNavigateToQuests;
 
-  const JournalScreen({super.key, required this.gameId});
+  const JournalScreen({super.key, required this.gameId, this.onNavigateToQuests});
 
   @override
   State<JournalScreen> createState() => _JournalScreenState();
@@ -71,6 +72,27 @@ class _JournalScreenState extends State<JournalScreen> {
             'Group them how you like but often it is best to keep each entry short, '
             'perhaps a paragraph or two.',
         condition: true,
+      );
+    }
+
+    // Post-wizard quest guidance
+    if (currentGame.sessions.length == 1 &&
+        currentSession != null &&
+        currentSession.entries.length == 1 &&
+        currentGame.quests.isEmpty) {
+      if (!mounted) return;
+      await TutorialService.showTutorialIfNeeded(
+        context: context,
+        tutorialId: 'post_wizard_quest_guidance',
+        title: 'Create Your First Quests',
+        message: 'Your story has begun! Consider creating quests to track your objectives.\n\n'
+            'Start with a quest for the situation in your opening scene. '
+            'Then create an Extreme or Epic rank quest for your character\'s '
+            'overarching life objective \u2014 this long-term goal will drive your '
+            'story forward across many sessions.',
+        condition: true,
+        actionLabel: 'Go to Quests',
+        onAction: widget.onNavigateToQuests,
       );
     }
   }

--- a/dart_rpg/lib/services/tutorial_service.dart
+++ b/dart_rpg/lib/services/tutorial_service.dart
@@ -61,6 +61,8 @@ class TutorialService {
     required String title,
     required String message,
     required bool condition,
+    String? actionLabel,
+    VoidCallback? onAction,
   }) async {
     final settings = Provider.of<SettingsProvider>(context, listen: false);
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
@@ -86,11 +88,19 @@ class TutorialService {
     if (context.mounted) {
       await showDialog(
         context: context,
-        builder: (context) => TutorialPopup(
+        builder: (dialogContext) => TutorialPopup(
           title: title,
           message: message,
+          actionLabel: actionLabel,
+          onAction: onAction != null
+              ? () {
+                  Navigator.pop(dialogContext);
+                  markTutorialAsShown(tutorialId);
+                  onAction();
+                }
+              : null,
           onClose: () {
-            Navigator.pop(context);
+            Navigator.pop(dialogContext);
             markTutorialAsShown(tutorialId);
           },
         ),

--- a/dart_rpg/lib/widgets/character/stat_panel.dart
+++ b/dart_rpg/lib/widgets/character/stat_panel.dart
@@ -7,6 +7,14 @@ class StatPanel extends StatelessWidget {
   final bool isEditable;
   final Function(int, int)? onStatChanged;
 
+  static const Map<String, String> _statDescriptions = {
+    'Edge': 'Quickness, agility, and prowess when fighting at range',
+    'Heart': 'Courage, willpower, empathy, and loyalty',
+    'Iron': 'Physical strength, endurance, and fighting at close quarters',
+    'Shadow': 'Stealth, deception, and cunning',
+    'Wits': 'Expertise, knowledge, and observation',
+  };
+
   const StatPanel({
     super.key,
     required this.stats,
@@ -33,7 +41,10 @@ class StatPanel extends StatelessWidget {
             children: [
               Expanded(
                 flex: 2,
-                child: Text(stat.name),
+                child: Tooltip(
+                  message: _statDescriptions[stat.name] ?? '',
+                  child: Text(stat.name),
+                ),
               ),
               Expanded(
                 flex: 3,

--- a/dart_rpg/lib/widgets/combat/combat_create_dialog.dart
+++ b/dart_rpg/lib/widgets/combat/combat_create_dialog.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../../models/quest.dart';
+
+/// Dialog for creating a new combat encounter.
+class CombatCreateDialog extends StatefulWidget {
+  final Function(String title, QuestRank rank) onCreate;
+
+  const CombatCreateDialog({
+    super.key,
+    required this.onCreate,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required Function(String title, QuestRank rank) onCreate,
+  }) {
+    return showDialog(
+      context: context,
+      builder: (context) => CombatCreateDialog(onCreate: onCreate),
+    );
+  }
+
+  @override
+  State<CombatCreateDialog> createState() => _CombatCreateDialogState();
+}
+
+class _CombatCreateDialogState extends State<CombatCreateDialog> {
+  final _titleController = TextEditingController();
+  QuestRank _selectedRank = QuestRank.dangerous;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Row(
+        children: [
+          Icon(Icons.sports_martial_arts, size: 20),
+          SizedBox(width: 8),
+          Text('New Combat'),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _titleController,
+            autofocus: true,
+            decoration: const InputDecoration(
+              labelText: 'Foe / Combat Title',
+              hintText: 'e.g., ICE Guardian',
+              border: OutlineInputBorder(),
+            ),
+            onSubmitted: (_) => _create(),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Rank',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          SegmentedButton<QuestRank>(
+            segments: QuestRank.values.map((rank) {
+              return ButtonSegment<QuestRank>(
+                value: rank,
+                label: Text(
+                  rank.displayName,
+                  style: const TextStyle(fontSize: 11),
+                ),
+                icon: Icon(rank.icon, size: 16),
+              );
+            }).toList(),
+            selected: {_selectedRank},
+            onSelectionChanged: (Set<QuestRank> selection) {
+              setState(() {
+                _selectedRank = selection.first;
+              });
+            },
+            showSelectedIcon: false,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _create,
+          child: const Text('Start Combat'),
+        ),
+      ],
+    );
+  }
+
+  void _create() {
+    final title = _titleController.text.trim();
+    if (title.isEmpty) return;
+
+    widget.onCreate(title, _selectedRank);
+    Navigator.pop(context);
+  }
+}

--- a/dart_rpg/lib/widgets/combat/combat_tracker_panel.dart
+++ b/dart_rpg/lib/widgets/combat/combat_tracker_panel.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import '../../models/combat.dart';
+import '../progress_track_widget.dart';
+
+/// Compact combat tracker widget designed for the QuickRollPanel.
+class CombatTrackerPanel extends StatelessWidget {
+  final Combat combat;
+  final VoidCallback? onMarkProgress;
+  final VoidCallback? onMarkProgressDouble;
+  final VoidCallback? onDecrease;
+  final VoidCallback? onProgressRoll;
+  final VoidCallback? onToggleControl;
+  final Function(CombatStatus)? onEnd;
+  final Function(int)? onTickChanged;
+
+  const CombatTrackerPanel({
+    super.key,
+    required this.combat,
+    this.onMarkProgress,
+    this.onMarkProgressDouble,
+    this.onDecrease,
+    this.onProgressRoll,
+    this.onToggleControl,
+    this.onEnd,
+    this.onTickChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = combat.status == CombatStatus.active;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Title row with rank badge and control toggle
+            Row(
+              children: [
+                Icon(
+                  combat.rank.icon,
+                  size: 16,
+                  color: combat.rank.color,
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    combat.title,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 13,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (isActive) ...[
+                  _buildControlChip(context),
+                ] else ...[
+                  Chip(
+                    label: Text(
+                      combat.status.displayName,
+                      style: const TextStyle(fontSize: 10),
+                    ),
+                    avatar: Icon(combat.status.icon, size: 14),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    padding: EdgeInsets.zero,
+                    labelPadding: const EdgeInsets.only(right: 4),
+                  ),
+                ],
+              ],
+            ),
+
+            const SizedBox(height: 4),
+
+            // Progress track
+            ProgressTrackWidget(
+              label: '',
+              value: combat.progress,
+              ticks: combat.progressTicks,
+              maxValue: 10,
+              isEditable: isActive,
+              showTicks: true,
+              onTickChanged: isActive ? onTickChanged : null,
+            ),
+
+            // Action buttons (only when active)
+            if (isActive) ...[
+              const SizedBox(height: 4),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  // Decrease
+                  _buildActionButton(
+                    context,
+                    icon: Icons.remove,
+                    tooltip: 'Decrease progress',
+                    onPressed: onDecrease,
+                    color: Theme.of(context).colorScheme.errorContainer,
+                    foreground: Theme.of(context).colorScheme.onErrorContainer,
+                  ),
+                  // Mark progress x1
+                  _buildActionButton(
+                    context,
+                    icon: Icons.add,
+                    tooltip: 'Mark progress',
+                    onPressed: onMarkProgress,
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    foreground: Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+                  // Mark progress x2
+                  _buildActionButton(
+                    context,
+                    label: 'x2',
+                    tooltip: 'Mark progress x2',
+                    onPressed: onMarkProgressDouble,
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    foreground: Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+                  // Take Decisive Action (progress roll)
+                  _buildActionButton(
+                    context,
+                    icon: Icons.casino,
+                    tooltip: 'Take Decisive Action',
+                    onPressed: onProgressRoll,
+                    color: Theme.of(context).colorScheme.secondaryContainer,
+                    foreground: Theme.of(context).colorScheme.onSecondaryContainer,
+                  ),
+                  // End combat
+                  PopupMenuButton<CombatStatus>(
+                    tooltip: 'End combat',
+                    onSelected: onEnd,
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: CombatStatus.won,
+                        child: Row(
+                          children: [
+                            Icon(Icons.emoji_events, size: 16, color: Colors.green),
+                            SizedBox(width: 8),
+                            Text('Won'),
+                          ],
+                        ),
+                      ),
+                      const PopupMenuItem(
+                        value: CombatStatus.lost,
+                        child: Row(
+                          children: [
+                            Icon(Icons.dangerous, size: 16, color: Colors.grey),
+                            SizedBox(width: 8),
+                            Text('Lost'),
+                          ],
+                        ),
+                      ),
+                      const PopupMenuItem(
+                        value: CombatStatus.fled,
+                        child: Row(
+                          children: [
+                            Icon(Icons.directions_run, size: 16, color: Colors.orange),
+                            SizedBox(width: 8),
+                            Text('Fled'),
+                          ],
+                        ),
+                      ),
+                    ],
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.errorContainer,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(
+                        Icons.flag,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildControlChip(BuildContext context) {
+    final inControl = combat.isInControl;
+    return GestureDetector(
+      onTap: onToggleControl,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: inControl
+              ? Colors.green.withAlpha(40)
+              : Colors.red.withAlpha(40),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: inControl ? Colors.green : Colors.red,
+            width: 1,
+          ),
+        ),
+        child: Text(
+          inControl ? 'In Control' : 'Bad Spot',
+          style: TextStyle(
+            fontSize: 10,
+            fontWeight: FontWeight.bold,
+            color: inControl ? Colors.green : Colors.red,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionButton(
+    BuildContext context, {
+    IconData? icon,
+    String? label,
+    required String tooltip,
+    VoidCallback? onPressed,
+    required Color color,
+    required Color foreground,
+  }) {
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: icon != null
+              ? Icon(icon, size: 16, color: foreground)
+              : Text(
+                  label!,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: foreground,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/dart_rpg/lib/widgets/journal/autocomplete_system.dart
+++ b/dart_rpg/lib/widgets/journal/autocomplete_system.dart
@@ -1,4 +1,5 @@
 import '../../models/character.dart';
+import '../../models/faction.dart';
 import '../../models/location.dart';
 
 /// A class for handling autocompletion of character and location references.
@@ -8,6 +9,9 @@ class AutocompleteSystem {
   
   /// Whether location suggestions are currently being shown.
   bool _showLocationSuggestions = false;
+
+  /// Whether faction suggestions are currently being shown.
+  bool _showFactionSuggestions = false;
   
   /// The current search text for filtering suggestions.
   String _currentSearchText = '';
@@ -41,6 +45,7 @@ class AutocompleteSystem {
     required int cursorPosition,
     required List<Character> characters,
     required List<Location> locations,
+    List<Faction> factions = const [],
   }) {
     final stopwatch = Stopwatch()..start();
     
@@ -54,13 +59,14 @@ class AutocompleteSystem {
     // Only proceed with more expensive operations if we might be in a mention
     final charBeforeCursor = cursorPosition > 0 ? text[cursorPosition - 1] : '';
     
-    // Special case: If we just typed @ or #, we always want to check for mentions
-    final justTypedMentionChar = charBeforeCursor == '@' || charBeforeCursor == '#';
-    
+    // Special case: If we just typed @, # or $, we always want to check for mentions
+    final justTypedMentionChar = charBeforeCursor == '@' || charBeforeCursor == '#' || charBeforeCursor == '\$';
+
     // If we're not in a mention context and didn't just type a mention character, return early
-    if (!justTypedMentionChar && 
-        !_showCharacterSuggestions && 
-        !_showLocationSuggestions) {
+    if (!justTypedMentionChar &&
+        !_showCharacterSuggestions &&
+        !_showLocationSuggestions &&
+        !_showFactionSuggestions) {
       _clearInlineSuggestion();
       _lastCheckDuration = stopwatch.elapsedMicroseconds;
       return false;
@@ -87,22 +93,24 @@ class AutocompleteSystem {
     if (currentWord.startsWith('@')) {
       if (currentWord.length > 1) {
         final searchText = currentWord.substring(1).toLowerCase();
-        
+
         // Only update if the search text has changed
-        if (searchText != _currentSearchText || _showLocationSuggestions) {
+        if (searchText != _currentSearchText || _showLocationSuggestions || _showFactionSuggestions) {
           _currentSearchText = searchText;
           _showCharacterSuggestions = true;
           _showLocationSuggestions = false;
+          _showFactionSuggestions = false;
           _suggestionStartPosition = wordStart;
-          _updateSuggestions(characters, locations);
+          _updateSuggestions(characters, locations, factions);
         }
-        
+
         _lastCheckDuration = stopwatch.elapsedMicroseconds;
         return true;
       } else {
         // Even if we just have @, we should set up the state for character suggestions
         _showCharacterSuggestions = true;
         _showLocationSuggestions = false;
+        _showFactionSuggestions = false;
         _suggestionStartPosition = wordStart;
         _lastCheckDuration = stopwatch.elapsedMicroseconds;
         return true;
@@ -110,22 +118,49 @@ class AutocompleteSystem {
     } else if (currentWord.startsWith('#')) {
       if (currentWord.length > 1) {
         final searchText = currentWord.substring(1).toLowerCase();
-        
+
         // Only update if the search text has changed
-        if (searchText != _currentSearchText || _showCharacterSuggestions) {
+        if (searchText != _currentSearchText || _showCharacterSuggestions || _showFactionSuggestions) {
           _currentSearchText = searchText;
           _showCharacterSuggestions = false;
           _showLocationSuggestions = true;
+          _showFactionSuggestions = false;
           _suggestionStartPosition = wordStart;
-          _updateSuggestions(characters, locations);
+          _updateSuggestions(characters, locations, factions);
         }
-        
+
         _lastCheckDuration = stopwatch.elapsedMicroseconds;
         return true;
       } else {
         // Even if we just have #, we should set up the state for location suggestions
         _showCharacterSuggestions = false;
         _showLocationSuggestions = true;
+        _showFactionSuggestions = false;
+        _suggestionStartPosition = wordStart;
+        _lastCheckDuration = stopwatch.elapsedMicroseconds;
+        return true;
+      }
+    } else if (currentWord.startsWith('\$')) {
+      if (currentWord.length > 1) {
+        final searchText = currentWord.substring(1).toLowerCase();
+
+        // Only update if the search text has changed
+        if (searchText != _currentSearchText || _showCharacterSuggestions || _showLocationSuggestions) {
+          _currentSearchText = searchText;
+          _showCharacterSuggestions = false;
+          _showLocationSuggestions = false;
+          _showFactionSuggestions = true;
+          _suggestionStartPosition = wordStart;
+          _updateSuggestions(characters, locations, factions);
+        }
+
+        _lastCheckDuration = stopwatch.elapsedMicroseconds;
+        return true;
+      } else {
+        // Even if we just have $, we should set up the state for faction suggestions
+        _showCharacterSuggestions = false;
+        _showLocationSuggestions = false;
+        _showFactionSuggestions = true;
         _suggestionStartPosition = wordStart;
         _lastCheckDuration = stopwatch.elapsedMicroseconds;
         return true;
@@ -143,11 +178,12 @@ class AutocompleteSystem {
     _suggestionStartPosition = null;
     _showCharacterSuggestions = false;
     _showLocationSuggestions = false;
+    _showFactionSuggestions = false;
     _filteredSuggestions = [];
   }
   
   /// Updates the list of suggestions based on the current search text.
-  void _updateSuggestions(List<Character> characters, List<Location> locations) {
+  void _updateSuggestions(List<Character> characters, List<Location> locations, List<Faction> factions) {
     // If the search text hasn't changed, use cached results
     if (_lastSearchText == _currentSearchText && _filteredSuggestions.isNotEmpty) {
       return;
@@ -172,6 +208,12 @@ class AutocompleteSystem {
           .where((l) => l.name.toLowerCase().contains(_currentSearchText))
           .take(10)
           .toList();
+    } else if (_showFactionSuggestions) {
+      // Limit to 10 suggestions for performance
+      _filteredSuggestions = factions
+          .where((f) => f.name.toLowerCase().contains(_currentSearchText))
+          .take(10)
+          .toList();
     } else {
       _filteredSuggestions = [];
     }
@@ -190,6 +232,9 @@ class AutocompleteSystem {
         final character = suggestion as Character;
         final handle = character.handle ?? character.getHandle();
         completionText = handle;
+      } else if (_showFactionSuggestions) {
+        final faction = suggestion as Faction;
+        completionText = faction.name.replaceAll(' ', '_');
       } else {
         completionText = suggestion.name;
       }
@@ -215,6 +260,9 @@ class AutocompleteSystem {
       final handle = entity.handle ?? entity.getHandle();
       mentionText = '@$handle';
       entityId = entity.id;
+    } else if (entity is Faction) {
+      mentionText = '\$${entity.name.replaceAll(' ', '_')}';
+      entityId = entity.id;
     } else {
       mentionText = '#${entity.name}';
       entityId = entity.id;
@@ -227,6 +275,7 @@ class AutocompleteSystem {
         'cursorPosition': mentionText.length,
         'entityId': entityId,
         'isCharacter': entity is Character,
+        'isFaction': entity is Faction,
       };
     }
     
@@ -249,21 +298,23 @@ class AutocompleteSystem {
         'cursorPosition': newCursorPosition,
         'entityId': entityId,
         'isCharacter': entity is Character,
+        'isFaction': entity is Faction,
       };
     }
-    
+
     // Replace the current word with the mention
     final newText = text.replaceRange(wordStart, cursorPosition, mentionText);
     final newCursorPosition = wordStart + mentionText.length;
-    
+
     // Clear the suggestion
     _clearInlineSuggestion();
-    
+
     return {
       'text': newText,
       'cursorPosition': newCursorPosition,
       'entityId': entityId,
       'isCharacter': entity is Character,
+      'isFaction': entity is Faction,
     };
   }
   
@@ -272,7 +323,7 @@ class AutocompleteSystem {
   /// Returns a map with the new text and the new cursor position if a suggestion
   /// was selected, null otherwise.
   Map<String, dynamic>? handleTabOrEnterKey(String text, int cursorPosition) {
-    if ((_showCharacterSuggestions || _showLocationSuggestions) &&
+    if ((_showCharacterSuggestions || _showLocationSuggestions || _showFactionSuggestions) &&
         _filteredSuggestions.isNotEmpty &&
         _inlineSuggestion != null) {
       return insertMention(_filteredSuggestions.first, text, cursorPosition);
@@ -295,7 +346,10 @@ class AutocompleteSystem {
   
   /// Gets whether location suggestions are currently being shown.
   bool get showLocationSuggestions => _showLocationSuggestions;
-  
+
+  /// Gets whether faction suggestions are currently being shown.
+  bool get showFactionSuggestions => _showFactionSuggestions;
+
   /// Gets the filtered list of suggestions.
   List<dynamic> get filteredSuggestions => List.unmodifiable(_filteredSuggestions);
   

--- a/dart_rpg/lib/widgets/journal/editor_toolbar.dart
+++ b/dart_rpg/lib/widgets/journal/editor_toolbar.dart
@@ -37,7 +37,10 @@ class EditorToolbar extends StatelessWidget {
   
   /// Callback for when the quest button is pressed.
   final VoidCallback? onQuestPressed;
-  
+
+  /// Callback for when the combat button is pressed.
+  final VoidCallback? onCombatPressed;
+
   /// Callback for when the linked items button is pressed.
   final VoidCallback? onLinkedItemsPressed;
   
@@ -56,6 +59,7 @@ class EditorToolbar extends StatelessWidget {
     this.onMovePressed,
     this.onOraclePressed,
     this.onQuestPressed,
+    this.onCombatPressed,
     this.onLinkedItemsPressed,
   });
   
@@ -191,7 +195,17 @@ class EditorToolbar extends StatelessWidget {
                     onPressed: onQuestPressed,
                   ),
                 ),
-                
+
+              // Combat button
+              if (onCombatPressed != null)
+                Tooltip(
+                  message: 'Combat (Ctrl+B)',
+                  child: IconButton(
+                    icon: const Icon(Icons.sports_martial_arts),
+                    onPressed: onCombatPressed,
+                  ),
+                ),
+
               // Linked Items button
               if (onLinkedItemsPressed != null)
                 Tooltip(

--- a/dart_rpg/lib/widgets/journal/editor_toolbar.dart
+++ b/dart_rpg/lib/widgets/journal/editor_toolbar.dart
@@ -22,7 +22,10 @@ class EditorToolbar extends StatelessWidget {
   
   /// Callback for when the location button is pressed.
   final VoidCallback onLocationPressed;
-  
+
+  /// Callback for when the faction button is pressed.
+  final VoidCallback onFactionPressed;
+
   /// Callback for when the image button is pressed.
   final VoidCallback onImagePressed;
   
@@ -48,6 +51,7 @@ class EditorToolbar extends StatelessWidget {
     required this.onNumberedListPressed,
     required this.onCharacterPressed,
     required this.onLocationPressed,
+    required this.onFactionPressed,
     required this.onImagePressed,
     this.onMovePressed,
     this.onOraclePressed,
@@ -139,7 +143,16 @@ class EditorToolbar extends StatelessWidget {
                   onPressed: onLocationPressed,
                 ),
               ),
-              
+
+              // Faction button
+              Tooltip(
+                message: 'Add Faction (\$)',
+                child: IconButton(
+                  icon: const Icon(Icons.groups),
+                  onPressed: onFactionPressed,
+                ),
+              ),
+
               // Image button
               Tooltip(
                 message: 'Add Image',

--- a/dart_rpg/lib/widgets/journal/journal_entry_editor.dart
+++ b/dart_rpg/lib/widgets/journal/journal_entry_editor.dart
@@ -50,7 +50,10 @@ class JournalEntryEditor extends StatefulWidget {
   
   /// Callback for when a quest is requested.
   final Function()? onQuestRequested;
-  
+
+  /// Callback for when combat is requested.
+  final Function()? onCombatRequested;
+
   /// Callback for when a new entry is requested.
   final Function()? onNewEntryRequested;
   
@@ -83,6 +86,7 @@ class JournalEntryEditor extends StatefulWidget {
     this.onMoveRequested,
     this.onOracleRequested,
     this.onQuestRequested,
+    this.onCombatRequested,
     this.onNewEntryRequested,
     this.onLinkedItemsPressed,
     this.controller,
@@ -875,6 +879,7 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
         onMovePressed: widget.onMoveRequested,
         onOraclePressed: widget.onOracleRequested,
         onQuestPressed: widget.onQuestRequested,
+        onCombatPressed: widget.onCombatRequested,
         onLinkedItemsPressed: _toggleLinkedItems,
       ) : null;
     

--- a/dart_rpg/lib/widgets/journal/journal_entry_editor.dart
+++ b/dart_rpg/lib/widgets/journal/journal_entry_editor.dart
@@ -35,7 +35,10 @@ class JournalEntryEditor extends StatefulWidget {
   
   /// Callback for when a location is linked.
   final Function(String locationId)? onLocationLinked;
-  
+
+  /// Callback for when a faction is linked.
+  final Function(String factionId)? onFactionLinked;
+
   /// Callback for when an image is added.
   final Function(String imageUrl)? onImageAdded;
   
@@ -75,6 +78,7 @@ class JournalEntryEditor extends StatefulWidget {
     required this.onChanged,
     this.onCharacterLinked,
     this.onLocationLinked,
+    this.onFactionLinked,
     this.onImageAdded,
     this.onMoveRequested,
     this.onOracleRequested,
@@ -229,14 +233,17 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
         widget.onChanged(_controller.text, _controller.text);
         
         // Notify parent about linked entity
-        if (result['isCharacter'] && widget.onCharacterLinked != null) {
+        if (result['isCharacter'] == true && widget.onCharacterLinked != null) {
           widget.onCharacterLinked!(result['entityId']);
           _linkedItemsManager.addCharacter(result['entityId']);
-        } else if (!result['isCharacter'] && widget.onLocationLinked != null) {
+        } else if (result['isFaction'] == true && widget.onFactionLinked != null) {
+          widget.onFactionLinked!(result['entityId']);
+          _linkedItemsManager.addFaction(result['entityId']);
+        } else if (result['isCharacter'] == false && result['isFaction'] == false && widget.onLocationLinked != null) {
           widget.onLocationLinked!(result['entityId']);
           _linkedItemsManager.addLocation(result['entityId']);
         }
-        
+
         return KeyEventResult.handled;
       }
     }
@@ -372,6 +379,55 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
     );
   }
   
+  // Show dialog to select a faction
+  void _showFactionSelectionDialog() {
+    final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    final currentGame = gameProvider.currentGame;
+
+    if (currentGame == null || currentGame.factions.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('No factions available'),
+        ),
+      );
+      return;
+    }
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Select Faction'),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 300,
+            child: ListView.builder(
+              itemCount: currentGame.factions.length,
+              itemBuilder: (context, index) {
+                final faction = currentGame.factions[index];
+
+                return ListTile(
+                  leading: Icon(faction.type.icon),
+                  title: Text(faction.name),
+                  onTap: () {
+                    Navigator.pop(context);
+                    _insertMention(faction);
+                  },
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   // Insert a mention at the current cursor position
   void _insertMention(dynamic entity) {
     final result = _autocompleteSystem.insertMention(
@@ -390,10 +446,13 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
     widget.onChanged(_controller.text, _controller.text);
     
     // Notify parent about linked entity
-    if (result['isCharacter'] && widget.onCharacterLinked != null) {
+    if (result['isCharacter'] == true && widget.onCharacterLinked != null) {
       widget.onCharacterLinked!(result['entityId']);
       _linkedItemsManager.addCharacter(result['entityId']);
-    } else if (!result['isCharacter'] && widget.onLocationLinked != null) {
+    } else if (result['isFaction'] == true && widget.onFactionLinked != null) {
+      widget.onFactionLinked!(result['entityId']);
+      _linkedItemsManager.addFaction(result['entityId']);
+    } else if (result['isCharacter'] == false && result['isFaction'] == false && widget.onLocationLinked != null) {
       widget.onLocationLinked!(result['entityId']);
       _linkedItemsManager.addLocation(result['entityId']);
     }
@@ -811,6 +870,7 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
         onNumberedListPressed: () => _insertFormatting('1. ', ''),
         onCharacterPressed: _showCharacterSelectionDialog,
         onLocationPressed: _showLocationSelectionDialog,
+        onFactionPressed: _showFactionSelectionDialog,
         onImagePressed: _addImage,
         onMovePressed: widget.onMoveRequested,
         onOraclePressed: widget.onOracleRequested,
@@ -825,8 +885,9 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
         cursorPosition: _controller.selection.baseOffset,
         characters: currentGame.characters,
         locations: currentGame.locations,
+        factions: currentGame.factions,
       );
-      
+
       _shouldCheckMentions = false;
     }
     
@@ -868,6 +929,7 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                 content: _controller.text,
                 linkedCharacterIds: _linkedItemsManager.linkedCharacterIds,
                 linkedLocationIds: _linkedItemsManager.linkedLocationIds,
+                linkedFactionIds: _linkedItemsManager.linkedFactionIds,
                 moveRolls: _linkedItemsManager.moveRolls,
                 oracleRolls: _linkedItemsManager.oracleRolls,
                 embeddedImages: _linkedItemsManager.embeddedImages,
@@ -889,6 +951,47 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                         final location = gp.currentGame!.locations
                             .firstWhereOrNull((l) => l.id == locationId);
                         if (location != null) _showLocationDetailsDialog(context, location);
+                      },
+                      onFactionTap: (factionId) {
+                        final faction = gp.currentGame!.factions
+                            .firstWhereOrNull((f) => f.id == factionId);
+                        if (faction != null) {
+                          showDialog(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: Text(faction.name),
+                              content: SingleChildScrollView(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Icon(faction.type.icon, size: 16),
+                                        const SizedBox(width: 4),
+                                        Text(faction.type.displayName),
+                                        const SizedBox(width: 16),
+                                        Text('Influence: ${faction.influence.displayName}'),
+                                      ],
+                                    ),
+                                    if (faction.description.isNotEmpty) ...[
+                                      const SizedBox(height: 16),
+                                      const Text('Description:', style: TextStyle(fontWeight: FontWeight.bold)),
+                                      const SizedBox(height: 4),
+                                      Text(faction.description),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(context),
+                                  child: const Text('Close'),
+                                ),
+                              ],
+                            ),
+                          );
+                        }
                       },
                       onMoveRollTap: (moveRoll) {
                         _showMoveRollDetailsDialog(context, moveRoll);
@@ -942,13 +1045,14 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                       // Always check if we just typed @ or #
                       if (cursorPosition > 0) {
                         final charBeforeCursor = value[cursorPosition - 1];
-                        if (charBeforeCursor == '@' || charBeforeCursor == '#') {
-                          // Immediately check for mentions when @ or # is typed
+                        if (charBeforeCursor == '@' || charBeforeCursor == '#' || charBeforeCursor == '\$') {
+                          // Immediately check for mentions when @, # or $ is typed
                           _autocompleteSystem.checkForMentions(
                             text: value,
                             cursorPosition: cursorPosition,
                             characters: currentGame.characters,
                             locations: currentGame.locations,
+                            factions: currentGame.factions,
                           );
                           
                           setState(() {});
@@ -957,8 +1061,9 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                       }
                       
                       // Continue checking if we're already in a mention context
-                      if (_autocompleteSystem.showCharacterSuggestions || 
-                          _autocompleteSystem.showLocationSuggestions) {
+                      if (_autocompleteSystem.showCharacterSuggestions ||
+                          _autocompleteSystem.showLocationSuggestions ||
+                          _autocompleteSystem.showFactionSuggestions) {
                         _shouldCheckMentions = true;
                         setState(() {});
                       }
@@ -975,12 +1080,13 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                         
                         if (wordStart < textBeforeCursor.length) {
                           final currentWord = textBeforeCursor.substring(wordStart);
-                          if (currentWord.startsWith('@') || currentWord.startsWith('#')) {
+                          if (currentWord.startsWith('@') || currentWord.startsWith('#') || currentWord.startsWith('\$')) {
                             _autocompleteSystem.checkForMentions(
                               text: _controller.text,
                               cursorPosition: cursorPosition,
                               characters: currentGame.characters,
                               locations: currentGame.locations,
+                              factions: currentGame.factions,
                             );
                             setState(() {});
                           }
@@ -991,10 +1097,11 @@ class _JournalEntryEditorState extends State<JournalEntryEditor> {
                 ),
                 
                 // Optimized inline suggestion overlay
-                if ((_autocompleteSystem.inlineSuggestion != null && 
+                if ((_autocompleteSystem.inlineSuggestion != null &&
                     _autocompleteSystem.suggestionStartPosition != null) ||
                     _autocompleteSystem.showCharacterSuggestions ||
-                    _autocompleteSystem.showLocationSuggestions)
+                    _autocompleteSystem.showLocationSuggestions ||
+                    _autocompleteSystem.showFactionSuggestions)
                   Builder(
                     builder: (context) {
                       // Handle the case where we just typed @ or # without any additional characters

--- a/dart_rpg/lib/widgets/journal/journal_entry_viewer.dart
+++ b/dart_rpg/lib/widgets/journal/journal_entry_viewer.dart
@@ -6,6 +6,7 @@ import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import '../../providers/game_provider.dart';
 import '../../providers/datasworn_provider.dart';
 import '../../models/character.dart';
+import '../../models/faction.dart';
 import '../../models/location.dart';
 import '../../models/journal_entry.dart';
 import '../../models/game.dart';
@@ -15,6 +16,7 @@ import '../../widgets/common/app_image_widget.dart';
 class JournalEntryViewer extends StatelessWidget {
   static final _characterRegex = RegExp(r'@(\w+)');
   static final _locationRegex = RegExp(r'#([^\s\[\]]+)');
+  static final _factionRegex = RegExp(r'\$([^\s\[\]]+)');
   static final _moveRegex = RegExp(r'\[(.*?) - (.*?)\]');
   static final _oracleRegex = RegExp(r'\[(.*?): (.*?)\]');
   static final _imageRegex = RegExp(r'!\[(?:.*?)\]\((.*?)\)');
@@ -28,6 +30,7 @@ class JournalEntryViewer extends StatelessWidget {
   final String content;
   final Function(Character character)? onCharacterTap;
   final Function(Location location)? onLocationTap;
+  final Function(Faction faction)? onFactionTap;
   final Function(MoveRoll moveRoll)? onMoveRollTap;
   final Function(OracleRoll oracleRoll)? onOracleRollTap;
   final List<MoveRoll> moveRolls;
@@ -38,6 +41,7 @@ class JournalEntryViewer extends StatelessWidget {
     required this.content,
     this.onCharacterTap,
     this.onLocationTap,
+    this.onFactionTap,
     this.onMoveRollTap,
     this.onOracleRollTap,
     this.moveRolls = const [],
@@ -82,7 +86,7 @@ class JournalEntryViewer extends StatelessWidget {
     for (final match in _locationRegex.allMatches(content)) {
       final name = match.group(1)!;
       final location = _findLocationByName(currentGame, name);
-      
+
       if (location != null) {
         allMatches.add(_TextMatch(
           start: match.start,
@@ -92,7 +96,22 @@ class JournalEntryViewer extends StatelessWidget {
         ));
       }
     }
-    
+
+    // Find faction references
+    for (final match in _factionRegex.allMatches(content)) {
+      final name = match.group(1)!;
+      final faction = _findFactionByName(currentGame, name);
+
+      if (faction != null) {
+        allMatches.add(_TextMatch(
+          start: match.start,
+          end: match.end,
+          type: _MatchType.faction,
+          data: faction,
+        ));
+      }
+    }
+
     // Find move references
     for (final match in _moveRegex.allMatches(content)) {
       final moveName = match.group(1)!;
@@ -290,6 +309,9 @@ class JournalEntryViewer extends StatelessWidget {
       case _MatchType.location:
         color = Colors.green;
         break;
+      case _MatchType.faction:
+        color = Colors.orange;
+        break;
       case _MatchType.move:
         final moveRoll = data as MoveRoll;
         color = getOutcomeColor(moveRoll.outcome);
@@ -328,8 +350,14 @@ class JournalEntryViewer extends StatelessWidget {
         if (onLocationTap != null) {
           onLocationTap!(data as Location);
         } else {
-          // Show a default dialog if no callback is provided
           _showDefaultLocationDialog(context, data as Location);
+        }
+        break;
+      case _MatchType.faction:
+        if (onFactionTap != null) {
+          onFactionTap!(data as Faction);
+        } else {
+          _showDefaultFactionDialog(context, data as Faction);
         }
         break;
       case _MatchType.move:
@@ -586,6 +614,51 @@ class JournalEntryViewer extends StatelessWidget {
     );
   }
   
+  void _showDefaultFactionDialog(BuildContext context, Faction faction) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(faction.name),
+          content: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Icon(faction.type.icon, size: 16),
+                    const SizedBox(width: 4),
+                    Text(faction.type.displayName),
+                    const SizedBox(width: 16),
+                    Text('Influence: ${faction.influence.displayName}'),
+                  ],
+                ),
+                if (faction.description.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Description:',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(faction.description),
+                ],
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   void _showDefaultOracleRollDialog(BuildContext context, OracleRoll oracleRoll) {
     showDialog(
       context: context,
@@ -634,6 +707,14 @@ class JournalEntryViewer extends StatelessWidget {
   Location? _findLocationByName(Game game, String name) {
     return game.locations.firstWhereOrNull(
       (l) => l.name.toLowerCase() == name.toLowerCase(),
+    );
+  }
+
+  Faction? _findFactionByName(Game game, String name) {
+    // Convert underscores back to spaces for lookup
+    final lookupName = name.replaceAll('_', ' ');
+    return game.factions.firstWhereOrNull(
+      (f) => f.name.toLowerCase() == lookupName.toLowerCase(),
     );
   }
 
@@ -716,6 +797,7 @@ class JournalEntryViewer extends StatelessWidget {
 enum _MatchType {
   character,
   location,
+  faction,
   move,
   oracle,
   image,

--- a/dart_rpg/lib/widgets/journal/linked_items_manager.dart
+++ b/dart_rpg/lib/widgets/journal/linked_items_manager.dart
@@ -1,5 +1,6 @@
 import '../../models/journal_entry.dart';
 import '../../models/character.dart';
+import '../../models/faction.dart';
 import '../../models/location.dart';
 
 /// A class for managing linked items in a journal entry.
@@ -9,7 +10,10 @@ class LinkedItemsManager {
   
   /// The list of linked location IDs.
   List<String> _linkedLocationIds = [];
-  
+
+  /// The list of linked faction IDs.
+  List<String> _linkedFactionIds = [];
+
   /// The list of move rolls.
   List<MoveRoll> _moveRolls = [];
   
@@ -26,6 +30,7 @@ class LinkedItemsManager {
   LinkedItemsManager({
     List<String>? linkedCharacterIds,
     List<String>? linkedLocationIds,
+    List<String>? linkedFactionIds,
     List<MoveRoll>? moveRolls,
     List<OracleRoll>? oracleRolls,
     List<String>? embeddedImages,
@@ -33,6 +38,7 @@ class LinkedItemsManager {
   }) {
     _linkedCharacterIds = linkedCharacterIds ?? [];
     _linkedLocationIds = linkedLocationIds ?? [];
+    _linkedFactionIds = linkedFactionIds ?? [];
     _moveRolls = moveRolls ?? [];
     _oracleRolls = oracleRolls ?? [];
     _embeddedImages = embeddedImages ?? [];
@@ -44,6 +50,7 @@ class LinkedItemsManager {
     return LinkedItemsManager(
       linkedCharacterIds: List.from(entry.linkedCharacterIds),
       linkedLocationIds: List.from(entry.linkedLocationIds),
+      linkedFactionIds: List.from(entry.linkedFactionIds),
       moveRolls: List.from(entry.moveRolls),
       oracleRolls: List.from(entry.oracleRolls),
       embeddedImages: List.from(entry.embeddedImages),
@@ -74,7 +81,19 @@ class LinkedItemsManager {
   void removeLocation(String locationId) {
     _linkedLocationIds.remove(locationId);
   }
-  
+
+  /// Adds a faction to the linked factions list.
+  void addFaction(String factionId) {
+    if (!_linkedFactionIds.contains(factionId)) {
+      _linkedFactionIds.add(factionId);
+    }
+  }
+
+  /// Removes a faction from the linked factions list.
+  void removeFaction(String factionId) {
+    _linkedFactionIds.remove(factionId);
+  }
+
   /// Adds a move roll to the move rolls list.
   void addMoveRoll(MoveRoll moveRoll) {
     _moveRolls.add(moveRoll);
@@ -123,6 +142,7 @@ class LinkedItemsManager {
   void updateJournalEntry(JournalEntry entry) {
     entry.linkedCharacterIds = List.from(_linkedCharacterIds);
     entry.linkedLocationIds = List.from(_linkedLocationIds);
+    entry.linkedFactionIds = List.from(_linkedFactionIds);
     entry.moveRolls = List.from(_moveRolls);
     entry.oracleRolls = List.from(_oracleRolls);
     entry.embeddedImages = List.from(_embeddedImages);
@@ -134,7 +154,10 @@ class LinkedItemsManager {
   
   /// Gets the list of linked location IDs.
   List<String> get linkedLocationIds => List.unmodifiable(_linkedLocationIds);
-  
+
+  /// Gets the list of linked faction IDs.
+  List<String> get linkedFactionIds => List.unmodifiable(_linkedFactionIds);
+
   /// Gets the list of move rolls.
   List<MoveRoll> get moveRolls => List.unmodifiable(_moveRolls);
   
@@ -156,17 +179,26 @@ class LinkedItemsManager {
   }
   
   /// Validates location references in the linked locations list.
-  /// 
+  ///
   /// Removes any location IDs that don't exist in the provided list of locations.
   void validateLocationReferences(List<Location> locations) {
     final validLocationIds = locations.map((l) => l.id).toSet();
     _linkedLocationIds.removeWhere((id) => !validLocationIds.contains(id));
   }
-  
+
+  /// Validates faction references in the linked factions list.
+  ///
+  /// Removes any faction IDs that don't exist in the provided list of factions.
+  void validateFactionReferences(List<Faction> factions) {
+    final validFactionIds = factions.map((f) => f.id).toSet();
+    _linkedFactionIds.removeWhere((id) => !validFactionIds.contains(id));
+  }
+
   /// Clears all linked items.
   void clear() {
     _linkedCharacterIds.clear();
     _linkedLocationIds.clear();
+    _linkedFactionIds.clear();
     _moveRolls.clear();
     _oracleRolls.clear();
     _embeddedImages.clear();

--- a/dart_rpg/lib/widgets/journal/linked_items_summary.dart
+++ b/dart_rpg/lib/widgets/journal/linked_items_summary.dart
@@ -4,6 +4,7 @@ import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import '../../providers/game_provider.dart';
 import '../../providers/datasworn_provider.dart';
 import '../../models/character.dart';
+import '../../models/faction.dart';
 import '../../models/location.dart';
 import '../../models/journal_entry.dart';
 import '../../utils/outcome_utils.dart';
@@ -13,6 +14,7 @@ class LinkedItemsSummary extends StatefulWidget {
   final JournalEntry journalEntry;
   final Function(String characterId)? onCharacterTap;
   final Function(String locationId)? onLocationTap;
+  final Function(String factionId)? onFactionTap;
   final Function(MoveRoll moveRoll)? onMoveRollTap;
   final Function(OracleRoll oracleRoll)? onOracleRollTap;
 
@@ -21,6 +23,7 @@ class LinkedItemsSummary extends StatefulWidget {
     required this.journalEntry,
     this.onCharacterTap,
     this.onLocationTap,
+    this.onFactionTap,
     this.onMoveRollTap,
     this.onOracleRollTap,
   });
@@ -33,6 +36,7 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
   bool _isExpanded = false;
   List<Character> _linkedCharacters = [];
   List<Location> _linkedLocations = [];
+  List<Faction> _linkedFactions = [];
 
   @override
   void didChangeDependencies() {
@@ -54,6 +58,7 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
     if (currentGame == null) {
       _linkedCharacters = [];
       _linkedLocations = [];
+      _linkedFactions = [];
       return;
     }
     _linkedCharacters = currentGame.characters
@@ -61,6 +66,9 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
         .toList();
     _linkedLocations = currentGame.locations
         .where((l) => widget.journalEntry.linkedLocationIds.contains(l.id))
+        .toList();
+    _linkedFactions = currentGame.factions
+        .where((f) => widget.journalEntry.linkedFactionIds.contains(f.id))
         .toList();
   }
 
@@ -75,6 +83,7 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
 
     final linkedCharacters = _linkedCharacters;
     final linkedLocations = _linkedLocations;
+    final linkedFactions = _linkedFactions;
     
     // Get move rolls
     final moveRolls = widget.journalEntry.moveRolls;
@@ -87,9 +96,10 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
                              widget.journalEntry.embeddedImageIds.isNotEmpty;
     
     // Check if there are any linked items
-    final hasLinkedItems = linkedCharacters.isNotEmpty || 
-                          linkedLocations.isNotEmpty || 
-                          moveRolls.isNotEmpty || 
+    final hasLinkedItems = linkedCharacters.isNotEmpty ||
+                          linkedLocations.isNotEmpty ||
+                          linkedFactions.isNotEmpty ||
+                          moveRolls.isNotEmpty ||
                           oracleRolls.isNotEmpty ||
                           hasEmbeddedImages;
     
@@ -124,7 +134,7 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
                   ),
                   const Spacer(),
                   Text(
-                    '${linkedCharacters.length + linkedLocations.length + moveRolls.length + oracleRolls.length + widget.journalEntry.embeddedImages.length + widget.journalEntry.embeddedImageIds.length} items',
+                    '${linkedCharacters.length + linkedLocations.length + linkedFactions.length + moveRolls.length + oracleRolls.length + widget.journalEntry.embeddedImages.length + widget.journalEntry.embeddedImageIds.length} items',
                     style: TextStyle(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                       fontSize: 14,
@@ -201,6 +211,34 @@ class _LinkedItemsSummaryState extends State<LinkedItemsSummary> {
                     ),
                   ],
                   
+                  // Factions
+                  if (linkedFactions.isNotEmpty) ...[
+                    const Divider(),
+                    const Text(
+                      'Factions',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: linkedFactions.map((faction) {
+                        return ActionChip(
+                          avatar: const Icon(Icons.groups, size: 16),
+                          label: Text(faction.name),
+                          onPressed: () {
+                            if (widget.onFactionTap != null) {
+                              widget.onFactionTap!(faction.id);
+                            }
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  ],
+
                   // Move Rolls
                   if (moveRolls.isNotEmpty) ...[
                     const Divider(),

--- a/dart_rpg/lib/widgets/journal/move_dialog.dart
+++ b/dart_rpg/lib/widgets/journal/move_dialog.dart
@@ -270,8 +270,10 @@ class MoveDialog {
     bool isEditing,
   ) async {
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    gameProvider.currentGame?.recordMoveUse(move.id, move.name, stat);
+    gameProvider.saveGame();
     final character = gameProvider.currentGame?.mainCharacter;
-    
+
     if (character == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
@@ -519,8 +521,10 @@ class MoveDialog {
   ) async {
     // Get the current game
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    gameProvider.currentGame?.recordMoveUse(move.id, move.name, null);
+    gameProvider.saveGame();
     final game = gameProvider.currentGame;
-    
+
     // Use the RollService to perform the roll
     final result = RollService.performProgressRoll(
       move: move,
@@ -693,7 +697,9 @@ class MoveDialog {
   ) async {
     // Get the current game provider
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
-    
+    gameProvider.currentGame?.recordMoveUse(move.id, move.name, null);
+    gameProvider.saveGame();
+
     try {
       // Use the existing makeQuestProgressRoll method
       final result = await gameProvider.makeQuestProgressRoll(questId);
@@ -824,6 +830,10 @@ class MoveDialog {
     // If move has embedded oracles (e.g. Ask the Oracle), don't close —
     // let the user use the MoveOraclePanel already shown in MoveDetails.
     if (move.hasEmbeddedOracles) return;
+
+    final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    gameProvider.currentGame?.recordMoveUse(move.id, move.name, null);
+    gameProvider.saveGame();
 
     // Use the RollService to perform the move
     final moveRoll = RollService.performNoRollMove(move: move);

--- a/dart_rpg/lib/widgets/journal/move_dialog.dart
+++ b/dart_rpg/lib/widgets/journal/move_dialog.dart
@@ -815,18 +815,22 @@ class MoveDialog {
 
   /// Performs a move that doesn't require a roll.
   static void _performNoRollMove(
-    BuildContext context, 
-    Move move, 
+    BuildContext context,
+    Move move,
     Function(MoveRoll moveRoll) onMoveRollAdded,
     Function(String text) onInsertText,
     bool isEditing,
   ) {
+    // If move has embedded oracles (e.g. Ask the Oracle), don't close —
+    // let the user use the MoveOraclePanel already shown in MoveDetails.
+    if (move.hasEmbeddedOracles) return;
+
     // Use the RollService to perform the move
     final moveRoll = RollService.performNoRollMove(move: move);
-    
+
     // Add the move roll to the journal entry
     onMoveRollAdded(moveRoll);
-    
+
     // Show the result
     showDialog(
       context: context,

--- a/dart_rpg/lib/widgets/journal/quick_roll_panel.dart
+++ b/dart_rpg/lib/widgets/journal/quick_roll_panel.dart
@@ -4,7 +4,9 @@ import 'package:provider/provider.dart';
 import '../../models/character.dart';
 import '../../models/combat.dart';
 import '../../models/move.dart';
+import '../../models/move_oracle.dart';
 import '../../models/journal_entry.dart';
+import '../../utils/dice_roller.dart';
 import '../../models/quest.dart';
 import '../../models/recent_move_entry.dart';
 import '../../providers/ai_config_provider.dart';
@@ -563,6 +565,12 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
   }
 
   void _performNoRoll(Move move) {
+    // If the move has embedded oracles (e.g. Ask the Oracle), show likelihood picker
+    if (move.hasEmbeddedOracles) {
+      _showOracleLikelihoodPicker(move);
+      return;
+    }
+
     final moveRoll = RollService.performNoRollMove(move: move);
 
     final gameProvider = Provider.of<GameProvider>(context, listen: false);
@@ -581,6 +589,97 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
     });
 
     gameProvider.saveGame();
+  }
+
+  void _showOracleLikelihoodPicker(Move move) {
+    final oracles = move.oracles;
+
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Choose likelihood for ${move.name}',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+              ...oracles.entries.map((entry) {
+                final oracle = entry.value;
+                // Build odds subtitle from rows (e.g. "1-75 Yes, 76-100 No")
+                final odds = oracle.rows
+                    .map((r) => '${r.minRoll}-${r.maxRoll} ${r.result}')
+                    .join(', ');
+                return ListTile(
+                  title: Text(oracle.name),
+                  subtitle: Text(odds, style: TextStyle(fontSize: 12, color: Colors.grey[600])),
+                  onTap: () {
+                    Navigator.pop(context);
+                    _rollAskTheOracle(move, entry.key, oracle);
+                  },
+                );
+              }),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _rollAskTheOracle(Move move, String oracleKey, MoveOracle oracle) {
+    final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    final game = gameProvider.currentGame;
+
+    // Roll the dice
+    final rollResult = DiceRoller.rollOracle(oracle.dice);
+    final total = rollResult['total'] as int;
+
+    // Find matching row
+    String result = 'Unknown';
+    for (final row in oracle.rows) {
+      if (total >= row.minRoll && total <= row.maxRoll) {
+        result = row.result;
+        break;
+      }
+    }
+
+    // Detect d100 match (doubles: 11, 22, 33, ..., 99, 00)
+    final isMatch = oracle.dice == '1d100' && total >= 11 && total % 11 == 0;
+
+    // Create a MoveRoll for the move usage
+    final moveRoll = RollService.performNoRollMove(move: move);
+    widget.onMoveRollAdded(moveRoll);
+
+    // Create an OracleRoll
+    final oracleName = '${move.name} (${oracle.name})';
+    final oracleRoll = OracleRoll(
+      oracleName: oracleName,
+      dice: [total],
+      result: isMatch ? '$result - Match!' : result,
+    );
+    widget.onOracleRollAdded?.call(oracleRoll);
+
+    // Format journal text
+    final matchSuffix = isMatch ? ' - Match!' : '';
+    final journalText = '[${move.name} (${oracle.name}) $total: $result$matchSuffix]';
+    widget.onInsertText(journalText);
+
+    // Record usage
+    if (game != null) {
+      game.recordMoveUse(move.id, move.name, null);
+      gameProvider.saveGame();
+    }
+
+    setState(() {
+      _lastRolledMove = move;
+      _lastMoveRoll = moveRoll;
+      _lastRollResult = {};
+    });
   }
 
   void _showStatPicker(Move move, dynamic character) {

--- a/dart_rpg/lib/widgets/journal/quick_roll_panel.dart
+++ b/dart_rpg/lib/widgets/journal/quick_roll_panel.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/character.dart';
+import '../../models/combat.dart';
 import '../../models/move.dart';
 import '../../models/journal_entry.dart';
 import '../../models/quest.dart';
@@ -11,6 +12,8 @@ import '../../providers/game_provider.dart';
 import '../../providers/datasworn_provider.dart';
 import '../../services/roll_service.dart';
 import '../character/panels/character_key_stats_panel.dart';
+import '../combat/combat_create_dialog.dart';
+import '../combat/combat_tracker_panel.dart';
 import '../sentient_ai_dialog.dart';
 import '../moves/roll_result_view.dart';
 import '../common/search_text_field.dart';
@@ -41,6 +44,7 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
   bool _showHeaderStats = false;
+  bool _showCombatSection = true;
 
   // Snapshot for header stat changes
   int _snapMomentum = 0;
@@ -169,6 +173,9 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
                     ),
                   ),
 
+                // Combat section
+                _buildCombatSection(context, currentGame, mainCharacter, gameProvider),
+
                 // Search bar
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -250,6 +257,10 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
   }
 
   Widget _buildHeader(BuildContext context, Character? mainCharacter) {
+    final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    final activeCombats = gameProvider.currentGame?.activeCombats ?? [];
+    final latestCombat = activeCombats.isNotEmpty ? activeCombats.last : null;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Row(
@@ -262,6 +273,39 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
               fontWeight: FontWeight.bold,
             ),
           ),
+          // In Control toggle (only when active combats exist)
+          if (latestCombat != null) ...[
+            const SizedBox(width: 8),
+            GestureDetector(
+              onTap: () async {
+                await gameProvider.toggleCombatControl(latestCombat.id);
+                final newState = latestCombat.isInControl ? 'In Control' : 'In a Bad Spot';
+                widget.onInsertText('\n*[Combat: $newState]*');
+                setState(() {});
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: latestCombat.isInControl
+                      ? Colors.green.withAlpha(40)
+                      : Colors.red.withAlpha(40),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(
+                    color: latestCombat.isInControl ? Colors.green : Colors.red,
+                    width: 1,
+                  ),
+                ),
+                child: Text(
+                  latestCombat.isInControl ? 'In Control' : 'Bad Spot',
+                  style: TextStyle(
+                    fontSize: 9,
+                    fontWeight: FontWeight.bold,
+                    color: latestCombat.isInControl ? Colors.green : Colors.red,
+                  ),
+                ),
+              ),
+            ),
+          ],
           const Spacer(),
           if (mainCharacter != null)
             IconButton(
@@ -503,6 +547,11 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
       _lastRollResult = rollResult;
     });
 
+    // Auto-update combat state based on combat move outcomes
+    if (_isCombatMove(move.id)) {
+      _applyCombatAutoUpdate(move.id, moveRoll.outcome, gameProvider);
+    }
+
     // Save game (persists recent moves + any momentum changes)
     gameProvider.saveGame();
 
@@ -578,13 +627,16 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
     final game = gameProvider.currentGame;
     if (game == null) return;
 
-    // For quest-related progress moves, show quest picker
     final quests = game.quests.where((q) => q.status == QuestStatus.ongoing).toList();
+    final isCombatMove = move.id == 'move:fe_runners/combat/take_decisive_action';
+    final activeCombats = isCombatMove ? game.activeCombats : <Combat>[];
 
-    if (quests.isEmpty) {
+    if (quests.isEmpty && activeCombats.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('No active quests to make a progress roll against'),
+        SnackBar(
+          content: Text(isCombatMove
+              ? 'No active quests or combats to make a progress roll against'
+              : 'No active quests to make a progress roll against'),
         ),
       );
       return;
@@ -600,12 +652,24 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
               const Padding(
                 padding: EdgeInsets.all(16),
                 child: Text(
-                  'Select quest for progress roll',
+                  'Select target for progress roll',
                   style: TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
+              // Combats first (only shown for Take Decisive Action)
+              ...activeCombats.map((combat) => ListTile(
+                leading: const Icon(Icons.sports_martial_arts, size: 20, color: Colors.red),
+                title: Text('Combat: ${combat.title}'),
+                subtitle: Text('Progress: ${combat.progress}/10'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _rollCombatProgressMove(combat);
+                },
+              )),
+              // Quests (shown for all progress moves)
               ...quests.map((quest) => ListTile(
-                title: Text(quest.title),
+                leading: const Icon(Icons.task_alt, size: 20),
+                title: Text('Quest: ${quest.title}'),
                 subtitle: Text('Progress: ${quest.progress}/10'),
                 onTap: () {
                   Navigator.pop(context);
@@ -794,6 +858,276 @@ class _QuickRollPanelState extends State<QuickRollPanel> {
         Navigator.pop(context);
       },
     );
+  }
+
+  // --- Combat ---
+
+  /// Map of combat move IDs to their auto-update rules
+  static const _combatMoveIds = {
+    'move:fe_runners/combat/enter_the_fray',
+    'move:fe_runners/combat/gain_ground',
+    'move:fe_runners/combat/strike',
+    'move:fe_runners/combat/clash',
+    'move:fe_runners/combat/react_under_fire',
+    'move:fe_runners/combat/take_decisive_action',
+  };
+
+  bool _isCombatMove(String moveId) => _combatMoveIds.contains(moveId);
+
+  void _applyCombatAutoUpdate(String moveId, String outcome, GameProvider gameProvider) {
+    final game = gameProvider.currentGame;
+    if (game == null) return;
+
+    final activeCombats = game.activeCombats;
+    if (activeCombats.isEmpty) return;
+
+    final combat = activeCombats.last;
+    final combatId = combat.id;
+
+    final isStrongHit = outcome == 'strong hit';
+    final isWeakHit = outcome == 'weak hit';
+    final isMiss = outcome == 'miss';
+
+    switch (moveId) {
+      case 'move:fe_runners/combat/enter_the_fray':
+        if (isStrongHit) {
+          gameProvider.setCombatControl(combatId, true);
+          widget.onInsertText('\n*[Combat: In Control]*');
+        } else if (isMiss) {
+          gameProvider.setCombatControl(combatId, false);
+          widget.onInsertText('\n*[Combat: In a Bad Spot]*');
+        }
+        break;
+
+      case 'move:fe_runners/combat/gain_ground':
+        if (isStrongHit || isWeakHit) {
+          gameProvider.setCombatControl(combatId, true);
+          widget.onInsertText('\n*[Combat: In Control]*');
+        } else if (isMiss) {
+          gameProvider.setCombatControl(combatId, false);
+          widget.onInsertText('\n*[Combat: In a Bad Spot]*');
+        }
+        break;
+
+      case 'move:fe_runners/combat/strike':
+        if (isStrongHit) {
+          gameProvider.setCombatControl(combatId, true);
+          gameProvider.addCombatTicksForRankDouble(combatId);
+          widget.onInsertText('\n*[Combat "${combat.title}": In Control, +progress x2 (${combat.progress}/10)]*');
+        } else if (isWeakHit) {
+          gameProvider.setCombatControl(combatId, false);
+          gameProvider.addCombatTicksForRankDouble(combatId);
+          widget.onInsertText('\n*[Combat "${combat.title}": In a Bad Spot, +progress x2 (${combat.progress}/10)]*');
+        } else if (isMiss) {
+          gameProvider.setCombatControl(combatId, false);
+          widget.onInsertText('\n*[Combat: In a Bad Spot]*');
+        }
+        break;
+
+      case 'move:fe_runners/combat/clash':
+        if (isStrongHit) {
+          gameProvider.setCombatControl(combatId, true);
+          gameProvider.addCombatTicksForRankDouble(combatId);
+          widget.onInsertText('\n*[Combat "${combat.title}": In Control, +progress x2 (${combat.progress}/10)]*');
+        } else if (isWeakHit) {
+          gameProvider.setCombatControl(combatId, false);
+          gameProvider.addCombatTicksForRank(combatId);
+          widget.onInsertText('\n*[Combat "${combat.title}": In a Bad Spot, +progress (${combat.progress}/10)]*');
+        } else if (isMiss) {
+          gameProvider.setCombatControl(combatId, false);
+          widget.onInsertText('\n*[Combat: In a Bad Spot]*');
+        }
+        break;
+
+      case 'move:fe_runners/combat/react_under_fire':
+        if (isStrongHit) {
+          gameProvider.setCombatControl(combatId, true);
+          widget.onInsertText('\n*[Combat: In Control]*');
+        }
+        // weak hit/miss: stay in bad spot (no change needed)
+        break;
+    }
+
+    setState(() {});
+  }
+
+  Widget _buildCombatSection(BuildContext context, dynamic currentGame, Character mainCharacter, GameProvider gameProvider) {
+    final activeCombats = currentGame.activeCombats as List<Combat>;
+
+    if (activeCombats.isEmpty && !_showCombatSection) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Section header with toggle and new combat button
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 8, 0),
+          child: Row(
+            children: [
+              GestureDetector(
+                onTap: () => setState(() => _showCombatSection = !_showCombatSection),
+                child: Row(
+                  children: [
+                    Icon(
+                      _showCombatSection ? Icons.expand_more : Icons.chevron_right,
+                      size: 16,
+                      color: Colors.grey[600],
+                    ),
+                    const SizedBox(width: 2),
+                    Text(
+                      'Combat',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.grey[600],
+                        letterSpacing: 0.5,
+                      ),
+                    ),
+                    if (activeCombats.isNotEmpty) ...[
+                      const SizedBox(width: 4),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withAlpha(30),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          '${activeCombats.length}',
+                          style: const TextStyle(fontSize: 9, color: Colors.red, fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.add, size: 16),
+                onPressed: () {
+                  CombatCreateDialog.show(
+                    context,
+                    onCreate: (title, rank) async {
+                      await gameProvider.createCombat(
+                        title,
+                        mainCharacter.id,
+                        rank,
+                      );
+                      widget.onInsertText('\n*[Combat Started: $title (${rank.displayName})]*');
+                      setState(() => _showCombatSection = true);
+                    },
+                  );
+                },
+                visualDensity: VisualDensity.compact,
+                tooltip: 'New Combat',
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+              ),
+            ],
+          ),
+        ),
+
+        // Active combat trackers
+        if (_showCombatSection)
+          ...activeCombats.map((combat) => CombatTrackerPanel(
+            combat: combat,
+            onMarkProgress: () async {
+              await gameProvider.addCombatTicksForRank(combat.id);
+              widget.onInsertText('\n*[Combat "${combat.title}": +progress (${combat.progress}/10)]*');
+              setState(() {});
+            },
+            onMarkProgressDouble: () async {
+              await gameProvider.addCombatTicksForRankDouble(combat.id);
+              widget.onInsertText('\n*[Combat "${combat.title}": +progress x2 (${combat.progress}/10)]*');
+              setState(() {});
+            },
+            onDecrease: () async {
+              await gameProvider.removeCombatTicksForRank(combat.id);
+              widget.onInsertText('\n*[Combat "${combat.title}": -progress (${combat.progress}/10)]*');
+              setState(() {});
+            },
+            onProgressRoll: () => _rollCombatProgressMove(combat),
+            onToggleControl: () async {
+              await gameProvider.toggleCombatControl(combat.id);
+              final newState = combat.isInControl ? 'In Control' : 'In a Bad Spot';
+              widget.onInsertText('\n*[Combat: $newState]*');
+              setState(() {});
+            },
+            onEnd: (status) async {
+              await gameProvider.endCombat(combat.id, status);
+              widget.onInsertText('\n*[Combat "${combat.title}" ended: ${status.displayName}]*');
+              setState(() {});
+            },
+            onTickChanged: (ticks) async {
+              await gameProvider.updateCombatProgressTicks(combat.id, ticks);
+              setState(() {});
+            },
+          )),
+
+        if (activeCombats.isNotEmpty || _showCombatSection)
+          const Divider(height: 8),
+      ],
+    );
+  }
+
+  Future<void> _rollCombatProgressMove(Combat combat) async {
+    final gameProvider = Provider.of<GameProvider>(context, listen: false);
+    final dataswornProvider = Provider.of<DataswornProvider>(context, listen: false);
+
+    try {
+      final result = await gameProvider.makeCombatProgressRoll(combat.id);
+
+      // Find the Take Decisive Action move
+      final move = dataswornProvider.moves.firstWhereOrNull(
+        (m) => m.id == 'move:fe_runners/combat/take_decisive_action',
+      );
+
+      final moveName = move?.name ?? 'Take Decisive Action';
+      final moveId = move?.id ?? 'take_decisive_action';
+
+      final moveRoll = MoveRoll(
+        moveName: moveName,
+        moveId: moveId,
+        rollType: 'progress_roll',
+        progressValue: combat.progress,
+        challengeDice: result['challengeDice'] as List<int>,
+        outcome: result['outcome'] as String,
+        actionDie: 0,
+        isMatch: (result['challengeDice'] as List<int>)[0] == (result['challengeDice'] as List<int>)[1],
+        moveData: {
+          'combatId': combat.id,
+          'combatTitle': combat.title,
+          'combatProgress': combat.progress,
+        },
+      );
+
+      widget.onMoveRollAdded(moveRoll);
+
+      final formattedText = moveRoll.getFormattedText();
+      final combatInfo = '\n**Combat:** ${combat.title} (Progress: ${combat.progress}/10)\n';
+      widget.onInsertText(formattedText + combatInfo);
+
+      setState(() {
+        _lastRolledMove = move;
+        _lastMoveRoll = moveRoll;
+        _lastRollResult = {
+          'outcome': result['outcome'],
+          'challengeDice': result['challengeDice'],
+          'progressValue': combat.progress,
+        };
+      });
+
+      gameProvider.saveGame();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Error: ${e.toString()}'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
   }
 
   // --- Helpers ---

--- a/dart_rpg/lib/widgets/moves/move_details.dart
+++ b/dart_rpg/lib/widgets/moves/move_details.dart
@@ -156,7 +156,7 @@ class MoveDetails extends StatelessWidget {
               onRoll: onProgressRoll,
               onQuestRoll: onQuestRoll,
             ),
-          ] else if (move.rollType == 'no_roll') ...[
+          ] else if (move.rollType == 'no_roll' && !move.hasEmbeddedOracles) ...[
             NoRollPanel(
               move: move,
               onPerform: onNoRoll,

--- a/dart_rpg/lib/widgets/quests/quest_card.dart
+++ b/dart_rpg/lib/widgets/quests/quest_card.dart
@@ -144,7 +144,7 @@ class _QuestCardState extends State<QuestCard> {
                     const Icon(Icons.person, size: 16),
                     const SizedBox(width: 4),
                     Text(
-                      'Character: ${widget.character.name}',
+                      'Character: ${widget.character.name}${widget.character.handle != null && widget.character.handle!.isNotEmpty ? ' (${widget.character.handle})' : ''}',
                       style: TextStyle(
                         color: Colors.grey[600],
                         fontSize: 14,

--- a/dart_rpg/lib/widgets/quests/quest_form.dart
+++ b/dart_rpg/lib/widgets/quests/quest_form.dart
@@ -91,7 +91,9 @@ class _QuestFormState extends State<QuestForm> {
             items: widget.characters.map((character) {
               return DropdownMenuItem<String>(
                 value: character.id,
-                child: Text(character.name),
+                child: Text(character.handle != null && character.handle!.isNotEmpty
+                    ? '${character.name} (${character.handle})'
+                    : character.name),
               );
             }).toList(),
             onChanged: (value) {

--- a/dart_rpg/lib/widgets/tutorial_popup.dart
+++ b/dart_rpg/lib/widgets/tutorial_popup.dart
@@ -8,18 +8,23 @@ class TutorialPopup extends StatelessWidget {
   final String message;
   final VoidCallback onClose;
   final bool showDisableOption;
+  final String? actionLabel;
+  final VoidCallback? onAction;
 
   /// Creates a tutorial popup.
-  /// 
+  ///
   /// The [title] and [message] are displayed in the popup.
   /// The [onClose] callback is called when the user dismisses the popup.
   /// If [showDisableOption] is true, a checkbox to disable all tutorials is shown.
+  /// If [actionLabel] and [onAction] are provided, an additional action button is shown.
   const TutorialPopup({
     super.key,
     required this.title,
     required this.message,
     required this.onClose,
     this.showDisableOption = true,
+    this.actionLabel,
+    this.onAction,
   });
 
   @override
@@ -48,6 +53,11 @@ class TutorialPopup extends StatelessWidget {
         ],
       ),
       actions: [
+        if (actionLabel != null && onAction != null)
+          FilledButton(
+            onPressed: onAction,
+            child: Text(actionLabel!),
+          ),
         TextButton(
           onPressed: onClose,
           child: const Text('Got it'),

--- a/dart_rpg/pubspec.yaml
+++ b/dart_rpg/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ^3.5.4

--- a/dart_rpg/test/widget/journal_entry_screen_test.dart
+++ b/dart_rpg/test/widget/journal_entry_screen_test.dart
@@ -198,8 +198,8 @@ void main() {
       // Verify the Oracle button is rendered
       expect(find.byIcon(Icons.casino), findsOneWidget);
       
-      // Verify the Move button is rendered
-      expect(find.byIcon(Icons.sports_martial_arts), findsOneWidget);
+      // Verify the Move button and Combat button are rendered (both use sports_martial_arts icon)
+      expect(find.byIcon(Icons.sports_martial_arts), findsNWidgets(2));
     });
     
     testWidgets('Move button shows snackbar when clicked in view mode', (WidgetTester tester) async {

--- a/dart_rpg/test/widget/quest_system_test.dart
+++ b/dart_rpg/test/widget/quest_system_test.dart
@@ -67,8 +67,8 @@ void main() {
       // Verify that the quest title is displayed
       expect(find.text('Test Quest'), findsOneWidget);
       
-      // Verify that the character name is displayed
-      expect(find.text('Character: Test Character'), findsOneWidget);
+      // Verify that the character name is displayed (handle is auto-generated from first name)
+      expect(find.text('Character: Test Character (Test)'), findsOneWidget);
       
       // Verify that the rank is displayed
       expect(find.text('Rank: Troublesome'), findsOneWidget);


### PR DESCRIPTION
## Summary
- Collapse World Truths section in game settings when truths are already set
- Record move usage from MoveDialog to quick roll history
- Add likelihood selection and d100 roll to Ask the Oracle in QuickRollPanel
- Add combat tracker embedded in journal QuickRollPanel
- Add double-tap to edit journal entries
- Add faction references to journal entries
- Show character handle next to name in quest form and quest card
- Fix custom oracles lost after datasworn reload
- Add tooltip descriptions to character stat names
- Add post-wizard quest guidance tutorial
- Bump version to 0.2.1

## Test plan
- [x] `flutter analyze` passes
- [ ] Verify World Truths section collapses when truths are set
- [ ] Verify multi-platform release builds trigger on release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)